### PR TITLE
fixing version check in case using deprecated functions

### DIFF
--- a/acf-ninja_forms-v5.php
+++ b/acf-ninja_forms-v5.php
@@ -149,7 +149,7 @@ class acf_field_ninja_forms extends acf_field {
     $field['type'] = 'select';
     ?>
       <select name="<?php echo $field['name'];echo ( true == $field['allow_multiple'] ? '[]' : null );?>" id="<?php echo $field['name'];?>" <?php echo ( true == $field['allow_multiple'] ? 'multiple' : null ); ?>>
-				<?php;
+				<?php
 				if( true == $field['allow_null'] ) { ?>
 					<option value="">-- <?php _e('None'); ?> --</option>
 				<?php

--- a/acf-ninja_forms-v5.php
+++ b/acf-ninja_forms-v5.php
@@ -85,6 +85,20 @@ class acf_field_ninja_forms extends acf_field {
 
   }
 
+  /*
+  *  is_ninja_forms_three()
+  *
+  *  We might be 3.0 but using deprecated version for compatibility!
+  *  Taken straight from NF
+  */
+
+  function is_ninja_forms_three() {
+    if ( get_option( 'ninja_forms_load_deprecated', false ) ) {
+      return false;
+    }
+
+    return version_compare( get_option( 'ninja_forms_version', '0' ), '3', '>='  );
+  }
 
   /*
   *  render_field()
@@ -111,7 +125,7 @@ class acf_field_ninja_forms extends acf_field {
     $field = array_merge($this->defaults, $field);
     $choices = array();
 
-		if ( version_compare( get_option( 'ninja_forms_version', '0.0.0' ), '3', '<' ) ) {
+    if ( !$this->is_ninja_forms_three() ) {
 			// Ninja forms 2.x functions
 			$forms = Ninja_Forms()->forms()->get_all();
 			if ( $forms ) {


### PR DESCRIPTION
Ran into an issue where I was using NF 3 but had to "rollback" to use the 2.9 functions.  The version check in this plugin missed that since it was still seeing that NF was 3.0.x.

This is now using a check from the NF add-ons themselves, checking for "ninja_forms_load_deprecated"
